### PR TITLE
Disable allowEmpty policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `allowEmpty: false` in the generated Application CR sync policy.
+
 ## [0.1.2] - 2021-05-20
 
 ### Added

--- a/pkg/argoapp/argoapp.go
+++ b/pkg/argoapp/argoapp.go
@@ -102,7 +102,7 @@ func NewApplication(config ApplicationConfig) (*unstructured.Unstructured, error
 			"syncPolicy": map[string]interface{}{
 				"automated": map[string]interface{}{
 					"prune":      true,
-					"allowEmpty": true,
+					"allowEmpty": false,
 					"selfHeal":   true,
 				},
 			},

--- a/pkg/argoapp/argoapp.go
+++ b/pkg/argoapp/argoapp.go
@@ -101,8 +101,8 @@ func NewApplication(config ApplicationConfig) (*unstructured.Unstructured, error
 			},
 			"syncPolicy": map[string]interface{}{
 				"automated": map[string]interface{}{
-					"prune":      true,
-					# If set to true allows deleting all application resources during automatic syncing ( false by default ).
+					"prune": true,
+					// If set to true allows deleting all application resources during automatic syncing (false by default).
 					"allowEmpty": false,
 					"selfHeal":   true,
 				},

--- a/pkg/argoapp/argoapp.go
+++ b/pkg/argoapp/argoapp.go
@@ -102,6 +102,7 @@ func NewApplication(config ApplicationConfig) (*unstructured.Unstructured, error
 			"syncPolicy": map[string]interface{}{
 				"automated": map[string]interface{}{
 					"prune":      true,
+					# If set to true allows deleting all application resources during automatic syncing ( false by default ).
 					"allowEmpty": false,
 					"selfHeal":   true,
 				},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18615

> ```
> allowEmpty: false # Allows deleting all application resources during automatic syncing ( false by default ).
> ```
> source: https://argoproj.github.io/argo-cd/operator-manual/application.yaml